### PR TITLE
Update _quarto.yml - cc logo

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -61,7 +61,7 @@ book:
     background: light
     left: |
       Except where otherwise noted, content on this site is licensed under a [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) license.<br><br>
-      ![BYNC](assets/SVG/by-nc.svg)
+      ![BYNC](by-nc.svg)
     center: "[OPEN.ED@PSU](https://oer.psu.edu/)"
     right: "[Privacy](https://www.psu.edu/web-privacy-statement/) | [Accessiblity](https://www.psu.edu/accessibilitystatement/) | [Copyright](https://www.psu.edu/copyright-information/) <br>
       [The Pennsylvania State University &copy; 2024](https://www.psu.edu/) | <br> [Leave Us Feedback](https://forms.office.com/r/GbC8H0pZhm)"


### PR DESCRIPTION
I updated the creative commons license logo path to not be in assets since when we copy the template files the svg is in the main root folder.