### PR TITLE
Update darkCustom.scss - margin top for headers

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -70,7 +70,15 @@ hr, .hr {
   display: none !important;
 }
 
+h2:not(.minitab_output *), .h2:not(.minitab_output *) {
+    margin-top: 3rem !important;
+}
+
 h3:not(.minitab_output *), .h3:not(.minitab_output *) {
+    margin-top: 3rem !important;
+}
+
+h4:not(.minitab_output *), .h4:not(.minitab_output *) {
     margin-top: 2rem !important;
 }
 


### PR DESCRIPTION
To add more whitespace and improve readability I added margin -top 3rem to all h2, h3 not minitab headers