### PR TITLE
Update lightCustom.scss - added margin top to example blocks

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -205,6 +205,7 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
   border-left: 1.3px solid !important;
   border-left-color: #3EA39E  !important; /*PA Creek*/
   margin-left: .65rem;
+  margin-top: 2.5em;
   padding-left: 1rem;
 
   .theorem-title {


### PR DESCRIPTION
Added margin-top: 2.5em; to example blocks to provide more space before examples