### PR TITLE
Update darkCustom.scss - added margin top to examples

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -281,6 +281,7 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
   border-left: 1.3px solid !important;
   border-left-color: #cfeceb !important; /*PA Creek light*/
   margin-left: .65rem;
+  margin-top: 2.5em;
   padding-left: 1rem;
 
   .theorem-title {


### PR DESCRIPTION
Added margin-top: 2.5em; to example blocks to provide more space before examples