### PR TITLE
Update lightCustom.scss - remove text-align right in tables

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -138,7 +138,7 @@ $table-cell-padding-x-sm:     .45rem;
 /*general tables*/
  tbody, tfoot, tr, td, th  {
       border-bottom: none !important;
-      text-align: right !important;
+      text-align: right;
  }
 
 /*---------------------------CALLOUTS ----------------------------------------------*/


### PR DESCRIPTION
I removed the !important for the text align right attribute of the general tables area. This allows us to set our own alignment in the table itself.