### PR TITLE
Update darkCustom.scss - remove important after text-align right in t…

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -210,7 +210,7 @@ $table-cell-padding-x-sm:     .45rem;
 /*general tables*/
  tbody, tfoot, tr, td, th  {
       border-bottom: none !important;
-      text-align: right !important;
+      text-align: right;
  }
 
 /*---------------------------CALLOUTS ----------------------------------------------*/


### PR DESCRIPTION
…ables

I removed the !important for the text align right attribute of the general tables area. This allows us to set our own alignment in the table itself.