### PR TITLE
Update darkCustom.scss - changed font size for .small in tables

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -193,6 +193,10 @@ ol li {
 
 /*--------------------------------TABLES--------------------------------------------*/
 
+.small {
+  font-size: 1em !important;  /*makes markdown tables have regular size text*/
+}
+
 .table-container {
   max-width: 100%; /* Set a maximum width for the container */
   overflow-x: auto; /* Enable horizontal scrolling when the content overflows */


### PR DESCRIPTION
This change makes the font sizes in markdown tables match the other text on the page and in html tables