### PR TITLE
Update darkCustom.scss changed nav-footer color

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -65,7 +65,7 @@ kbd, .kbd {
 }
 
 .nav-footer {
-  background-color: black !important;
+  background-color: #001e44 !important;
 }
 
 /*-----------------------------HEADERS---------------------------------------------- */


### PR DESCRIPTION
The nav-footer was set to black in dark mode, but now it's #001e44 to match the rest of the site in dark mode.