### PR TITLE
Update darkCustom.scss Reduced margin top for h4s in .alert

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -93,6 +93,10 @@ h4:not(.minitab_output *), .h4:not(.minitab_output *) {
     margin-top: 2rem !important;
 }
 
+.alert-light > h4 {
+  margin-top: 0rem !important;
+}
+
 .nomargin {
   margin-top: -1.5em;
 }


### PR DESCRIPTION
This reduces the space above the h4 header "answer" in an example .alert block