### PR TITLE
Update lightCustom.scss - added :not(.tab-content *) to active

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -97,7 +97,7 @@ div.sidebar.sidebar-navigation.rollup.quarto-sidebar-toggle-contents, nav.sideba
     background-color: #E4E5E7  !important;  /*PA Limestone Light*/
 }
 
-.active > * > * {
+.active > * > * :not(.tab-content *){
   color: #0d6efd !important;
   font-weight: 800 !important;
 }


### PR DESCRIPTION
The active >*>* was making everything inside an active tab set panel to be this color and bolded. I had to add the :not(.tab-content *) so this doesn't happen.