### PR TITLE
Update darkCustom.scss - added :not(.tab-content) to active

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -149,7 +149,7 @@ div.sidebar.sidebar-navigation.rollup.quarto-sidebar-toggle-contents, nav.sideba
   color: #F2F2F4 !important;  /*PA Limestone extra light*/
 }
 
-.active > * > * {
+.active > * > * :not(.tab-content *){
   color: #F9EDDC !important;  /*PA Sky light */
   font-weight: 800 !important;
 }


### PR DESCRIPTION
The active >*>* was making everything inside an active tab set panel to be this color and bolded. I had to add the :not(.tab-content *) so this doesn't happen.