### PR TITLE
Update lightCustom.scss - moved .active into div.sidebar

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -95,11 +95,10 @@ h1.title >.chapter-number:before {
 /*left nav bar background*/
 div.sidebar.sidebar-navigation.rollup.quarto-sidebar-toggle-contents, nav.sidebar.sidebar-navigation:not(.rollup) {
     background-color: #E4E5E7  !important;  /*PA Limestone Light*/
-}
-
-.active > * > * {
-  color: #0d6efd !important;
-  font-weight: 800 !important;
+    .active > * > *{
+      color: #314D64 !important;
+      font-weight: bolder !important;
+     }
 }
 
 a:hover > * > * {


### PR DESCRIPTION
The .active >*>* was causing issues with tab sets since the active tab would then style according to this. By moving it into the div.sidebar css now it will only apply to that particular place.  Also, the color changed to #314D64 to make it more accessible. I also made the font wt to 'bolder'