### PR TITLE
Update darkCustom.scss  moved .active into the div.sidebar css

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -143,11 +143,12 @@ h1.title >.chapter-number:before {
 /*left nav bar background*/
 div.sidebar.sidebar-navigation.rollup.quarto-sidebar-toggle-contents, nav.sidebar.sidebar-navigation:not(.rollup) {
     background-color:  #001E44     !important;  /*Nittany navy*/
+  .active > * > *{
+      color: #ffffff !important;
+      font-weight: bolder !important;
+     }
 }
 
-.sidebar-navigation a {
-  color: #F2F2F4 !important;  /*PA Limestone extra light*/
-}
 
 .active > * > * {
   color: #F9EDDC !important;  /*PA Sky light */


### PR DESCRIPTION
The .active >> was causing issues with tab sets since the active tab would then style according to this. By moving it into the div.sidebar css now it will only apply to that particular place. Also, the color changed to white. I also made the font wt to 'bolder' .active > * > *{