### PR TITLE
Update index.qmd   -top yaml additions for grid and toc-title

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -4,10 +4,17 @@ title-block-banner-color: light
 titlegraphic: fiveoone_banner.png
 sidebar: false
 
+grid:
+      content-mode: standard
+      margin-width: 390px  #right side margin width so it's wider on this home page because of the topics 
+      body-width: 1100px 
+ 
+toc-title: "Contents"  #changes the top of the TOC instead of saying in this lesson
+
 listing:
   id: lessons
-  categories: unnumbered
-  contents:
+  categories: cloud
+  contents:  #adjust as needed to the number of lessons
     - Lesson0.qmd
     - Lesson01.qmd
     - Lesson02.qmd


### PR DESCRIPTION
Added grid to the top yaml of the home page so that the topics cloud was not in a narrow space and extending down beyond view. Also, instead of saying 'in this lesson' at the top of the toc on the home page I changed it to 'contents'