### PR TITLE
Update lightCustom.scss - left nav bar text to black

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -106,6 +106,10 @@ a:hover > * > * {
   color: #0d6efd !important;
 }
 
+/*make left nav links black*/
+div.sidebar-item-container {
+  color: black !important;
+}
 /*-----------------------------------TOC------------------------------------*/
 
 #TOC * > a.nav-link:hover *:not(i) {


### PR DESCRIPTION
This change makes the navigation links on the left black which stands out better against the gray background