### PR TITLE
 Update lightCustom.scss - updated minitab tables to not put a border…

### DIFF
--- a/lightCustom.scss
+++ b/lightCustom.scss
@@ -387,6 +387,7 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
 
   .table th:first-child, .table td:first-child {
     text-align: left !important;
+    border-bottom: none!important;
   }
   
   .table th.special-th {


### PR DESCRIPTION
… on the bottom of row headers

with the new row header class it put a bottom border under all of the first column headers.. this removes that