### PR TITLE
Update darkCustom.scss - updated minitab tables first row headers

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -471,6 +471,7 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
   .table th:first-child, .table td:first-child {
     text-align: left !important;
     border-bottom: none!important;
+    font-weight: normal !important;
   }
   
   .table th.special-th {

--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -470,6 +470,7 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
   
   .table th:first-child, .table td:first-child {
     text-align: left !important;
+    border-bottom: none!important;
   }
   
   .table th.special-th {


### PR DESCRIPTION
with the new row header class it put a bottom border under all of the first column headers.. this removes that