### PR TITLE
Update darkCustom.scss - updated minitab tables first row headers

### DIFF
--- a/darkCustom.scss
+++ b/darkCustom.scss
@@ -468,10 +468,15 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
       padding: .75px 7.65px !important;
   }
   
-  .table th:first-child, .table td:first-child {
+  .table tbody tr th:first-child {
+    font-weight: normal !important;
+    border-bottom: none!important;
+    text-align: left !important;
+  }
+  
+  .table td:first-child {
     text-align: left !important;
     border-bottom: none!important;
-    font-weight: normal !important;
   }
   
   .table th.special-th {
@@ -480,7 +485,6 @@ $callout-color-note: #f4f8fc !default; /* defines the light blue callout color *
   
   thead, th, .header {
     border-bottom: 1.3px solid white !important;
-    text-align: right !important;
     border-top: none !important;
   }
   


### PR DESCRIPTION
I also removed the right align class added to header under minitab styles. This allows us to use markdown to determine the alignment.